### PR TITLE
fix phases detection

### DIFF
--- a/functions
+++ b/functions
@@ -69,7 +69,7 @@ require_add_volumes() {
       
       # "phases" key is optional
       set +eo pipefail
-      PHASES=$(require_get_app_plugins "[\"$DOKKU_REQUIRE_PREFIX\"][\"volumes\"][${COUNT}][\"phases\"]" < "$APP_JSON_FILE" 2>&1)
+      PHASES=$(require_get_app_plugins "[\"$DOKKU_REQUIRE_PREFIX\"][\"volumes\"][${COUNT}][\"phases\"]" < "$APP_JSON_FILE" 2>/dev/null)
       set -eo pipefail
       
       if [[ -z "$PHASES" ]]; then 


### PR DESCRIPTION
Prevent PHASES from being set to pythons KeyError traceback if the property is missing in app.json.

This patch discards errors completely, so I'm not sure this is the way to go.

Finally, thank you really much for this plugin! I have not fiddled around with it much yet, but it seems to fill a big gap towards more automation / less maintenance - one of the reasons I'm using dokku after all.